### PR TITLE
Add company id column to transactions

### DIFF
--- a/elixir/lib/homework/transactions/transaction.ex
+++ b/elixir/lib/homework/transactions/transaction.ex
@@ -1,6 +1,7 @@
 defmodule Homework.Transactions.Transaction do
   use Ecto.Schema
   import Ecto.Changeset
+  alias Homework.Companies.Company
   alias Homework.Merchants.Merchant
   alias Homework.Users.User
 
@@ -11,6 +12,7 @@ defmodule Homework.Transactions.Transaction do
     field(:debit, :boolean, default: false)
     field(:description, :string)
 
+    belongs_to(:company, Company, type: :binary_id, foreign_key: :company_id)
     belongs_to(:merchant, Merchant, type: :binary_id, foreign_key: :merchant_id)
     belongs_to(:user, User, type: :binary_id, foreign_key: :user_id)
 
@@ -20,7 +22,7 @@ defmodule Homework.Transactions.Transaction do
   @doc false
   def changeset(transaction, attrs) do
     transaction
-    |> cast(attrs, [:user_id, :amount, :debit, :description, :merchant_id])
-    |> validate_required([:user_id, :amount, :debit, :description, :merchant_id])
+    |> cast(attrs, [:amount, :company_id, :debit, :description, :merchant_id, :user_id])
+    |> validate_required([:amount, :company_id, :debit, :description, :merchant_id, :user_id])
   end
 end

--- a/elixir/lib/homework_web/resolvers/transactions_resolver.ex
+++ b/elixir/lib/homework_web/resolvers/transactions_resolver.ex
@@ -1,4 +1,5 @@
 defmodule HomeworkWeb.Resolvers.TransactionsResolver do
+  alias Homework.Companies
   alias Homework.Merchants
   alias Homework.Transactions
   alias Homework.Users
@@ -22,6 +23,13 @@ defmodule HomeworkWeb.Resolvers.TransactionsResolver do
   """
   def merchant(_root, _args, %{source: %{merchant_id: merchant_id}}) do
     {:ok, Merchants.get_merchant!(merchant_id)}
+  end
+
+  @doc """
+  Get the company associated with a transaction
+  """
+  def company(_root, _args, %{source: %{company_id: company_id}}) do
+    {:ok, Companies.get_company!(company_id)}
   end
 
   @doc """

--- a/elixir/lib/homework_web/schemas/transactions_schema.ex
+++ b/elixir/lib/homework_web/schemas/transactions_schema.ex
@@ -10,6 +10,7 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
     field(:id, non_null(:id))
     field(:user_id, :id)
     field(:amount, :integer)
+    field(:company_id, :id)
     field(:credit, :boolean)
     field(:debit, :boolean)
     field(:description, :string)
@@ -24,6 +25,10 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
     field(:merchant, :merchant) do
       resolve(&TransactionsResolver.merchant/3)
     end
+
+    field(:company, :company) do
+      resolve(&TransactionsResolver.company/3)
+    end
   end
 
   object :transaction_mutations do
@@ -31,6 +36,7 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
     field :create_transaction, :transaction do
       arg(:user_id, non_null(:id))
       arg(:merchant_id, non_null(:id))
+      arg(:company_id, non_null(:id))
       @desc "amount is in cents"
       arg(:amount, non_null(:integer))
       arg(:credit, non_null(:boolean))
@@ -45,6 +51,7 @@ defmodule HomeworkWeb.Schemas.TransactionsSchema do
       arg(:id, non_null(:id))
       arg(:user_id, non_null(:id))
       arg(:merchant_id, non_null(:id))
+      arg(:company_id, non_null(:id))
       @desc "amount is in cents"
       arg(:amount, non_null(:integer))
       arg(:credit, non_null(:boolean))

--- a/elixir/priv/repo/migrations/20210311172407_add_company_id_column_to_transactions.exs
+++ b/elixir/priv/repo/migrations/20210311172407_add_company_id_column_to_transactions.exs
@@ -1,0 +1,9 @@
+defmodule Homework.Repo.Migrations.AddCompanyIdColumnToTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table("transactions") do
+      add(:company_id, references(:companies, type: :uuid, on_delete: :nothing))
+    end
+  end
+end


### PR DESCRIPTION
Adds the company_id column to the transactions table, updates the transaction ecto model, and updates the transaction query and mutations to include company relations